### PR TITLE
Remove dirt lore

### DIFF
--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -4812,4 +4812,3 @@ recipes:
         dirt:
           material: DIRT
           amount: 1
-          name: Dirt!


### PR DESCRIPTION
This name keeps the dirt from being usable in any factory recipe. If you want to use it, you have to first place all of it and mine it again to remove the name, which is very annoying and pointless. @TealNerd 