### PR TITLE
Changed bio lab recipes

### DIFF
--- a/Citadel/config.yml
+++ b/Citadel/config.yml
@@ -140,6 +140,7 @@ non_reinforceables:
  - CROPS
  - POTATO
  - NETHER_WARTS
+ - END_GATEWAY
 reset_player_state: 300
 enable_maturation: true
 # The max amount of reinforcements to keep loaded

--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -400,6 +400,7 @@ factories:
      - dirt_to_grass
      - dirt_to_podzol
      - dirt_to_mycelium
+     - dirt_to_coarse_dirt
      - sapling_to_oak
      - sapling_to_spruce
      - sapling_to_birch
@@ -1522,6 +1523,19 @@ recipes:
       mycelium:
         material: MYCEL
         amount: 64
+  dirt_to_coarse_dirt:
+    production_time: 4s
+    name: Convert Dirt to Coarse Dirt
+    type: PRODUCTION
+    input:
+      dirt:
+        material: DIRT
+        amount: 64
+    output:
+      coarse_dirt:
+        material: DIRT
+        amount: 64
+        durability: 1
   sapling_to_oak:
     production_time: 4s
     name: Convert Sapling to Oak

--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -419,6 +419,8 @@ factories:
         material: CHEST
         amount: 32
     recipes:
+     - make_chests_from_logs
+     - make_chests_from_logs2
      - make_fences
      - make_signs
      - make_ladders
@@ -2585,6 +2587,34 @@ recipes:
         material: CHEST
         amount: 32
     factory: Carpentry Factory
+  make_chests_from_logs:
+    forceInclude: true
+    production_time: 4s
+    name: Make Chests from Logs
+    type: PRODUCTION
+    input:
+      log:
+        material: LOG
+        durability: -1
+        amount: 128
+    output:
+      chest:
+        material: CHEST
+        amount: 64
+  make_chests_from_logs_2:
+    forceInclude: true
+    production_time: 4s
+    name: Make Chests from Logs 2
+    type: PRODUCTION
+    input:
+      log:
+        material: LOG_2
+        durability: -1
+        amount: 128
+    output:
+      chest:
+        material: CHEST
+        amount: 64
   make_fences:
     production_time: 4s
     name: Make Fences

--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -425,6 +425,7 @@ factories:
      - make_bookshelves
      - make_trapdoors
      - make_wood_doors
+     - make_fence_gates
      - make_casing
      - make_crates
      - repair_carpentry
@@ -2595,7 +2596,7 @@ recipes:
     output:
       fence:
         material: FENCE
-        amount: 256
+        amount: 128
   make_signs:
     production_time: 4s
     name: Make Signs
@@ -2619,7 +2620,7 @@ recipes:
     output:
       ladder:
         material: LADDER
-        amount: 256
+        amount: 128
   make_bookshelves:
     production_time: 4s
     name: Make Bookshelves
@@ -2634,7 +2635,7 @@ recipes:
     output:
       bookshelves:
         material: BOOKSHELF
-        amount: 64
+        amount: 20
   make_trapdoors:
     production_time: 4s
     name: Make Trap Doors
@@ -2658,7 +2659,20 @@ recipes:
     output:
       door:
         material: WOOD_DOOR
-        amount: 32
+        amount: 128
+  make_fence_gates:
+    forceInclude: true
+    production_time: 4s
+    name: Make Fence Gates
+    type: PRODUCTION
+    input:
+      chest:
+        material: CHEST
+        amount: 16
+    output:
+      fence_gate:
+        material: FENCE_GATE
+        amount: 64
   repair_carpentry:
     production_time: 4s
     name: Repair Factory

--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -409,8 +409,6 @@ factories:
      - sapling_to_dark_oak
      - make_mushroom_brown
      - make_mushroom_red
-     - make_mushroom_stem
-     - make_mushroom_pores
      - repair_bio_lab
   carpentry:
     type: FCC
@@ -4180,31 +4178,6 @@ recipes:
       red_mushroom_block:
         material: HUGE_MUSHROOM_2
         durability: 14
-        amount: 16
-  make_mushroom_stem:
-    type: PRODUCTION
-    name: Make Stem Mushroom Blocks
-    production_time: 4s
-    input:
-      brown_mushroom:
-        material: BROWN_MUSHROOM
-        amount: 64
-    output:
-      stem_mushroom_block:
-        material: HUGE_MUSHROOM_1
-        durability: 10
-        amount: 16
-  make_mushroom_pores:
-    type: PRODUCTION
-    name: Make Pore Mushroom Blocks
-    production_time: 4s
-    input:
-      brown_mushroom:
-        material: BROWN_MUSHROOM
-        amount: 64
-    output:
-      pore_mushroom_block:
-        material: HUGE_MUSHROOM_1
         amount: 16
   bake_cookies:
     forceInclude: true

--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -1522,6 +1522,7 @@ recipes:
         material: MYCEL
         amount: 64
   dirt_to_coarse_dirt:
+    forceInclude: true
     production_time: 4s
     name: Convert Dirt to Coarse Dirt
     type: PRODUCTION


### PR DESCRIPTION
Added a dirt_to_coarse_dirt recipe (grass and mycelium won't grow on coarse dirt, so it's useful for landscaping for a bare-earth look, plus has it's own texture) and removed the make_mushroom_stem and make_mushroom_pores recipes since those blocks haven't been obtainable as items since MC 1.5 and the recipes both just produce the same brown mushroom cap blocks as the -make_mushroom_brown recipe.