### PR TITLE
Added Redstone Lamp Recipe

### DIFF
--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -111,6 +111,7 @@ factories:
      - make_prismarine_bricks
      - make_dark_prismarine
      - make_sea_lantern
+     - make_redstone_lamp
      - pack_ice
      - repair_aesthetics
   dye_wool:
@@ -1312,6 +1313,21 @@ recipes:
     output:
       sea_lantern:
         material: SEA_LANTERN
+        amount: 32
+  make_redstone_lamp:
+    production_time: 4s
+    name: Make Redstone Lamp
+    type: PRODUCTION
+    input:
+      glowstone:
+        material: GLOWSTONE
+        amount: 32
+      redstone:
+        material: BLAZE_POWDER
+        amount: 8
+    output:
+      redstone_lamp:
+        material: REDSTONE_LAMP
         amount: 32
   make_diamond_helm:
     production_time: 4s

--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -1315,6 +1315,7 @@ recipes:
         material: SEA_LANTERN
         amount: 32
   make_redstone_lamp:
+    forceInclude: true
     production_time: 4s
     name: Make Redstone Lamp
     type: PRODUCTION


### PR DESCRIPTION
Added a recipe to make redstone lamps in the aesthetics factory as there was no current factory recipe to make them. As these blocks largely have no purpose other than decoration, I thought blaze powder was a fair substitute for redstone dust and matched the theme of using a mob item to create lighting blocks ( ex. squid ink in sea lantern recipe).