### PR TITLE
Reset ender pearl gravity to vanilla minecraft

### DIFF
--- a/Humbug/config.yml
+++ b/Humbug/config.yml
@@ -63,7 +63,7 @@ prevent_land_boats: true
 prevent_ender_pearl_save: true
 fix_vehicle_logout_bug: true
 fix_minecart_reenter_bug: true
-ender_pearl_gravity: 0.06
+ender_pearl_gravity: 0.03
 saturation_multiplier: 0.0
 hunger_slowdown: 0.0
 prevent_tree_wraparound: true

--- a/PvPTweaks/config.yml
+++ b/PvPTweaks/config.yml
@@ -11,7 +11,7 @@ tweaks:
     #cooldown in ticks, 300 = 15 seconds
     cooldown: 300
     refundPearl: true
-    gravity: 0.06
+    gravity: 0.03
   PotionTweaks:
     drinkableDurationMultiplier: 1.0
     splashDurationMultiplier: 0.75


### PR DESCRIPTION
Do pearls really need to travel half the distance compared to vanilla especially with player velocity affecting the trajectory?