### PR TITLE
Fix /ppfree abuse

### DIFF
--- a/PrisonPearl/config.yml
+++ b/PrisonPearl/config.yml
@@ -1,4 +1,4 @@
-free_tppearl: true
+free_tppearl: false
 autofree_worldborder: true
 prison_musthotbar: true
 prison_stealing: true


### PR DESCRIPTION
This change makes it so that players don't get teleported out of the end to their captors when they get `/ppfree`d. Previously, the captor could steal the prisoner's inventory by `/ppfree`ing them and then re-pearling them. Now, getting `/ppfree`d means you get a chat notification and will respawn normally next time you die or enter the end portal.