### PR TITLE
Don't refund the pearl in 1.12

### DIFF
--- a/PvPTweaks/config.yml
+++ b/PvPTweaks/config.yml
@@ -10,7 +10,7 @@ tweaks:
   PearlTweaks:
     #cooldown in ticks, 300 = 15 seconds
     cooldown: 300
-    refundPearl: true
+    refundPearl: false
     gravity: 0.06
   PotionTweaks:
     drinkableDurationMultiplier: 1.0


### PR DESCRIPTION
This applies only to 1.12. Cancelling the event already refunds the pearl, so refunding it again with the plugin dupes it.