### PR TITLE
Add END_GATEWAY as non-reinforceable

### DIFF
--- a/Citadel/config.yml
+++ b/Citadel/config.yml
@@ -114,6 +114,7 @@ reinforcements:
   #hit_points: 60
 non_reinforceables:
  - BEDROCK
+ - END_GATEWAY
  - ENDER_PORTAL_FRAME
  - SAPLING
  - LONG_GRASS


### PR DESCRIPTION
Previously, you could acid block end portal blocks (it doesn't drop anything, but still an issue because you *could* completely remove the portal.