### PR TITLE
Remove withers from ClearLagg limiter

### DIFF
--- a/ClearLag/config.yml
+++ b/ClearLag/config.yml
@@ -168,7 +168,6 @@ chunk-entity-limiter:
     - squid
     - villager
     - wither_skeleton
-    - wither
     - wolf
     - zombie
     - zombie_villager


### PR DESCRIPTION
peter5930 - Today at 8:31 AM
Could withers be taken off the clearlagg chunk entity limiter?  Nobody's going to crash the server by spawning a million withers and it means everyone has to modmail for beacons because they can't get withers to spawn.