### PR TITLE
fix redstone lamp recipe

### DIFF
--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -1331,7 +1331,7 @@ recipes:
         amount: 8
     output:
       redstone_lamp:
-        material: REDSTONE_LAMP
+        material: REDSTONE_LAMP_OFF
         amount: 32
   make_diamond_helm:
     production_time: 4s


### PR DESCRIPTION
`REDSTONE_LAMP` does not exist, so the recipe was just eating the items