### PR TITLE
Balance cookie, pie, bread and potatoes w.r.t. both exp and food value

### DIFF
--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -774,6 +774,7 @@ recipes:
         durability: 1
   bake_bread:
     production_time: 4s
+    fuel_consumption_intervall: 40t
     name: Bake Bread
     type: PRODUCTION
     input:
@@ -786,6 +787,7 @@ recipes:
         amount: 48
   bake_potatoes:
     production_time: 4s
+    fuel_consumption_intervall: 40t
     name: Bake Potatoes
     type: PRODUCTION
     input:
@@ -4657,24 +4659,26 @@ recipes:
     forceInclude: true
     type: PRODUCTION
     name: Bake Cookies
-    production_time: 4s
+    production_time: 32s
+    fuel_consumption_intervall: 40t
     input:
       wheat:
         material: WHEAT
-        amount: 256
+        amount: 128
       cocoa:
         material: INK_SACK
-        amount: 128
+        amount: 64
         durability: 3
     output:
       cookie:
         material: COOKIE
-        amount: 2048
+        amount: 1024
   bake_pie:
     forceInclude: true
     type: PRODUCTION
     name: Bake Pumpkin Pie
-    production_time: 4s
+    production_time: 32s
+    fuel_consumption_intervall: 40t
     input:
       sugar:
         material: SUGAR


### PR DESCRIPTION
I believe this is the fairest way to answer complaints about food I've been hearing.
These new values work off the reasoning that the time it takes to cook the food should be based on how much it feeds you, and the charcoal cost of the food should be in line with how much exp it creates.
To create some consistency between numbers, the values for the cookie recipe have been halved.
Please see the table below for details about the numbers.
I am open to discussion, particularly about the pie charcoal cost, seeing as it is not a product used for exp. I put quite some effort into this balance suggestion.

https://i.imgur.com/LIeKIaW.png