### PR TITLE
Turn off Humbug personal death messages

### DIFF
--- a/Humbug/config.yml
+++ b/Humbug/config.yml
@@ -14,7 +14,7 @@ enderdragon: true
 joinquitkick: false
 deathannounce: false
 deathlog: true
-deathpersonal: true
+deathpersonal: false
 deathred: false
 ender_backpacks: false
 endergrief: false


### PR DESCRIPTION
Already handled by another plugin.