### PR TITLE
Add Red Netherbrick recipe

### DIFF
--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -70,6 +70,7 @@ factories:
      - smelt_stone
      - smelt_glass
      - smelt_netherrack
+     - smelt_red_netherbrick
      - smelt_bricks
      - smelt_hard_clay
      - smelt_sandstone
@@ -1131,6 +1132,22 @@ recipes:
       netherrack:
         material: NETHERRACK
         amount: 64
+    output:
+      netherbrick:
+        material: NETHER_BRICK
+        amount: 64
+  smelt_red_netherbrick:
+    forceInclude: true
+    production_time: 4s
+    name: Smelt Red Netherbrick
+    type: PRODUCTION
+    input:
+      netherrack:
+        material: NETHERRACK
+        amount: 32
+      nether_wart:
+        material: NETHER_STALK
+        amount: 32
     output:
       netherbrick:
         material: NETHER_BRICK

--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -1149,8 +1149,8 @@ recipes:
         material: NETHER_STALK
         amount: 32
     output:
-      netherbrick:
-        material: NETHER_BRICK
+      red_netherbrick:
+        material: RED_NETHER_BRICK
         amount: 64
   charcoal_from_logs:
     production_time: 4s


### PR DESCRIPTION
This patch adds a recipe for Red Netherbrick and force includes it. It uses the 50% material discount that the normal Netherbrick recipe also uses.