### PR TITLE
Add stone variant recipes and purpur from fruit to Aesthetics

### DIFF
--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -1259,7 +1259,7 @@ recipes:
       quartz:
         material: QUARTZ_BLOCK
         amount: 64
-  aggregate_andesite
+  aggregate_andesite:
     forceInclude: true
     production_time: 4s
     name: Aggregate Andesite
@@ -1276,7 +1276,7 @@ recipes:
         material: STONE
         amount: 64
         durability: 5
-  aggregate_diorite
+  aggregate_diorite:
     forceInclude: true
     production_time: 4s
     name: Aggregate Diorite
@@ -1293,7 +1293,7 @@ recipes:
         material: STONE
         amount: 64
         durability: 3
-  aggregate_granite
+  aggregate_granite:
     forceInclude: true
     production_time: 4s
     name: Aggregate Granite
@@ -1363,7 +1363,7 @@ recipes:
       purpur:
         material: PURPUR_BLOCK
         amount: 64
-  condense_purpur_fruit
+  condense_purpur_fruit:
     forceInclude: true
     production_time: 4s
     name: Make Purpur from Fruit

--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -106,9 +106,13 @@ factories:
      - make_circle_stone_brick
      - make_mossy_cobble
      - make_quartz
+     - aggregate_andesite
+     - aggregate_diorite
+     - aggregate_granite
      - make_red_sand
      - clean_red_sand
      - make_purpur
+     - condense_purpur_fruit
      - make_prismarine
      - make_prismarine_bricks
      - make_dark_prismarine
@@ -1255,6 +1259,57 @@ recipes:
       quartz:
         material: QUARTZ_BLOCK
         amount: 64
+  aggregate_andesite
+    forceInclude: true
+    production_time: 4s
+    name: Aggregate Andesite
+    type: PRODUCTION
+    input:
+      cobblestone:
+        material: COBBLESTONE
+        amount: 64
+      quartz:
+        material: QUARTZ_BLOCK
+        amount: 4
+    output:
+      andesite:
+        material: STONE
+        amount: 64
+        durability: 5
+  aggregate_diorite
+    forceInclude: true
+    production_time: 4s
+    name: Aggregate Diorite
+    type: PRODUCTION
+    input:
+      cobblestone:
+        material: COBBLESTONE
+        amount: 64
+      quartz:
+        material: QUARTZ_BLOCK
+        amount: 8
+    output:
+      diorite:
+        material: STONE
+        amount: 64
+        durability: 3
+  aggregate_granite
+    forceInclude: true
+    production_time: 4s
+    name: Aggregate Granite
+    type: PRODUCTION
+    input:
+      cobblestone:
+        material: COBBLESTONE
+        amount: 64
+      quartz:
+        material: QUARTZ_BLOCK
+        amount: 16
+    output:
+      granite:
+        material: STONE
+        amount: 64
+        durability: 1
   make_red_sand:
     production_time: 4s
     name: Make Red SAND
@@ -1304,6 +1359,19 @@ recipes:
         material: INK_SACK
         amount: 8
         durability: 5
+    output:
+      purpur:
+        material: PURPUR_BLOCK
+        amount: 64
+  condense_purpur_fruit
+    forceInclude: true
+    production_time: 4s
+    name: Make Purpur from Fruit
+    type: PRODUCTION
+    input:
+      fruit:
+        material: CHORUS_FRUIT_POPPED
+        amount: 64
     output:
       purpur:
         material: PURPUR_BLOCK


### PR DESCRIPTION
This commit adds the much-needed andesite, diorite, and granite to the aesthetics factory. These 3 variants of stone did not generate in most biomes due to a config error, and an easy way to manufacture them is needed. The 3 recipes added stay as close to the ratios imposed by vanilla Minecraft as possible, but make one vital change: you can use quartz blocks made by hand OR by the aesthetics factory to make these stones, reducing the cost for these aesthetic blocks. It also introduces a 50% discount on quartz to make it favourable to vanilla crafting.

The 4th recipe added adds a way to make purpur the vanilla way: from cooked ('popped') chorus fruit. This follows the netherbrick crafting recipe cost (25% of vanilla cost).