### PR TITLE
Remove aggregate special stone recipes

### DIFF
--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -107,9 +107,6 @@ factories:
      - make_circle_stone_brick
      - make_mossy_cobble
      - make_quartz
-     - aggregate_andesite
-     - aggregate_diorite
-     - aggregate_granite
      - make_red_sand
      - clean_red_sand
      - make_purpur
@@ -1276,57 +1273,6 @@ recipes:
       quartz:
         material: QUARTZ_BLOCK
         amount: 64
-  aggregate_andesite:
-    forceInclude: true
-    production_time: 4s
-    name: Aggregate Andesite
-    type: PRODUCTION
-    input:
-      cobblestone:
-        material: COBBLESTONE
-        amount: 64
-      quartz:
-        material: QUARTZ_BLOCK
-        amount: 4
-    output:
-      andesite:
-        material: STONE
-        amount: 64
-        durability: 5
-  aggregate_diorite:
-    forceInclude: true
-    production_time: 4s
-    name: Aggregate Diorite
-    type: PRODUCTION
-    input:
-      cobblestone:
-        material: COBBLESTONE
-        amount: 64
-      quartz:
-        material: QUARTZ_BLOCK
-        amount: 8
-    output:
-      diorite:
-        material: STONE
-        amount: 64
-        durability: 3
-  aggregate_granite:
-    forceInclude: true
-    production_time: 4s
-    name: Aggregate Granite
-    type: PRODUCTION
-    input:
-      cobblestone:
-        material: COBBLESTONE
-        amount: 64
-      quartz:
-        material: QUARTZ_BLOCK
-        amount: 16
-    output:
-      granite:
-        material: STONE
-        amount: 64
-        durability: 1
   make_red_sand:
     production_time: 4s
     name: Make Red SAND

--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -107,6 +107,9 @@ factories:
      - make_circle_stone_brick
      - make_mossy_cobble
      - make_quartz
+     - aggregate_andesite
+     - aggregate_diorite
+     - aggregate_granite
      - make_red_sand
      - clean_red_sand
      - make_purpur
@@ -1273,6 +1276,59 @@ recipes:
       quartz:
         material: QUARTZ_BLOCK
         amount: 64
+  aggregate_andesite:
+    forceInclude: true
+    production_time: 4s
+    name: Aggregate Andesite
+    type: PRODUCTION
+    input:
+      cobblestone:
+        material: COBBLESTONE
+        amount: 64
+      diorite:
+        material: STONE
+        amount: 64
+        durability: 3
+    output:
+      andesite:
+        material: STONE
+        amount: 64
+        durability: 5
+  aggregate_diorite:
+    forceInclude: true
+    production_time: 4s
+    name: Aggregate Diorite
+    type: PRODUCTION
+    input:
+      cobblestone:
+        material: COBBLESTONE
+        amount: 64
+      quartz:
+        material: QUARTZ
+        amount: 64
+    output:
+      diorite:
+        material: STONE
+        amount: 64
+        durability: 3
+  aggregate_granite:
+    forceInclude: true
+    production_time: 4s
+    name: Aggregate Granite
+    type: PRODUCTION
+    input:
+      diorite:
+        material: STONE
+        amount: 64
+        durability: 3
+      quartz:
+        material: QUARTZ
+        amount: 64
+    output:
+      granite:
+        material: STONE
+        amount: 64
+        durability: 1
   make_red_sand:
     production_time: 4s
     name: Make Red SAND


### PR DESCRIPTION
The special stones, Andesite, Granite, and Diorite, are already abundant on the server. They are not available in all biomes, according to @CaptainKlutz due to a config error, however regardless of the cause this does not cause issues, and instead actually makes the game more interesting in the spirit of RealisticBiomes- people who don't live near mesa or savanna biomes will need to trade with those that do. Markets for special stone already exist in the two largest cities, Mount Augusta and Yoahtl, addressing this need organically, and adding this recipe hurts the people who invested time solving this shortage in-game.

One year into the server being alive, we should not be adding config recipes for resources that are already possible to obtain in-game, and instead should only add recipes for those few that can't be.