### PR TITLE
Delete red netherbrick recipe

### DIFF
--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -70,7 +70,6 @@ factories:
      - smelt_stone
      - smelt_glass
      - smelt_netherrack
-     - smelt_red_netherbrick
      - smelt_bricks
      - smelt_hard_clay
      - smelt_sandstone
@@ -1139,22 +1138,6 @@ recipes:
     output:
       netherbrick:
         material: NETHER_BRICK
-        amount: 64
-  smelt_red_netherbrick:
-    forceInclude: true
-    production_time: 4s
-    name: Smelt Red Netherbrick
-    type: PRODUCTION
-    input:
-      netherrack:
-        material: NETHERRACK
-        amount: 32
-      nether_wart:
-        material: NETHER_STALK
-        amount: 32
-    output:
-      red_netherbrick:
-        material: RED_NETHER_BRICK
         amount: 64
   charcoal_from_logs:
     production_time: 4s

--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -70,6 +70,7 @@ factories:
      - smelt_stone
      - smelt_glass
      - smelt_netherrack
+     - smelt_red_netherbrick
      - smelt_bricks
      - smelt_hard_clay
      - smelt_sandstone
@@ -1139,6 +1140,22 @@ recipes:
       netherbrick:
         material: NETHER_BRICK
         amount: 64
+  smelt_red_netherbrick:
+    forceInclude: true
+    production_time: 4s
+    name: Smelt Red Netherbrick
+    type: PRODUCTION
+    input:
+      netherrack:
+        material: NETHERRACK
+        amount: 64
+      nether_wart:
+        material: NETHER_STALK
+        amount: 64
+    output:
+      red_netherbrick:
+        material: RED_NETHER_BRICK
+        amount: 32
   charcoal_from_logs:
     production_time: 4s
     name: Make Charcoal from Logs


### PR DESCRIPTION
It's possible to craft red netherbrick in-game. If there is high demand for red netherbrick, let the in-game markets solve the issue.