### PR TITLE
Make Aggregate Andesite recipe on par with crafting

### DIFF
--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -1292,7 +1292,7 @@ recipes:
     output:
       andesite:
         material: STONE
-        amount: 64
+        amount: 128
         durability: 5
   aggregate_diorite:
     forceInclude: true


### PR DESCRIPTION
Fix a mistake where the recipe for producing Andesite gave 1 Andesite for every 1 Cobble + 1 Diorite, instead of 2 Andesite which one would get by crafting manually.