### PR TITLE
Create exceptions to stop ClearLag culling common named mobs

### DIFF
--- a/ClearLag/config.yml
+++ b/ClearLag/config.yml
@@ -139,36 +139,36 @@ chunk-entity-limiter:
     - bat
     - blaze
     - cave_spider
-    - chicken
-    - cow
+    - chicken !hasName
+    - cow !hasName
     - creeper
-    - donkey
+    - donkey !hasName
     - elder_guardian
     - enderman
-    - endermite
+    - endermite !hasName
     - ghast
     - guardian
-    - horse
-    - iron_golem
+    - horse !hasName
+    - iron_golem !hasName
     - magma_cube
-    - mule
-    - mushroom_cow
-    - ocelot
-    - pig
+    - mule !hasName
+    - mushroom_cow !hasName
+    - ocelot !hasName
+    - pig !hasName
     - pig_zombie
-    - polar_bear
-    - rabbit
-    - sheep
+    - polar_bear !hasName
+    - rabbit !hasName
+    - sheep !hasName
     - silverfish
     - skeleton
     - skeleton_horse
     - slime
-    - snowman
+    - snowman !hasName
     - spider
     - squid
     - villager
     - wither_skeleton
-    - wolf
+    - wolf !hasName
     - zombie
     - zombie_villager
   # - Pig liveTime=100 <- This mob will be REMOVED if it's been alive for 100 ticks (5 seconds)


### PR DESCRIPTION
Adds a few exceptions to ClearLag to stop them clearing the most common named mobs.