### PR TITLE
Reduce grace period before permabreaking factories

### DIFF
--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -6,7 +6,7 @@ default_fuel:
 default_fuel_consumption_intervall: 1s
 default_menu_factory: Dirt Factory
 default_return_rate: 0.5
-default_break_grace_period: 1000d
+default_break_grace_period: 2d
 decay_intervall: 1h
 decay_amount: 21
 default_health: 10000

--- a/FactoryMod/config.yml
+++ b/FactoryMod/config.yml
@@ -6,7 +6,7 @@ default_fuel:
 default_fuel_consumption_intervall: 1s
 default_menu_factory: Dirt Factory
 default_return_rate: 0.5
-default_break_grace_period: 2d
+default_break_grace_period: 14d
 decay_intervall: 1h
 decay_amount: 21
 default_health: 10000
@@ -610,6 +610,7 @@ factories:
   compactor:
     type: FCC
     name: Compactor
+    health: 50000
     citadelBreakReduction: 0.8
     setupcost:
       iron_block:


### PR DESCRIPTION
to 2 days to make it not super OP to leave your factory semi-broken and repair only to use it. This causes repair costs to be relevant as recurring costs instead of one time use to coin-operate your factory.