### PR TITLE
Moderate Bastion break time reduction

### DIFF
--- a/Bastion/config.yml
+++ b/Bastion/config.yml
@@ -27,7 +27,7 @@ bastions:
     effectRadius: 10
     includeY: true
     startScaleFactor: 10
-    finalScaleFactor: 0.95
+    finalScaleFactor: 1.00
     warmupTime: 172800000
     erosionPerDay: 0
     regenPerDay: 5
@@ -63,7 +63,7 @@ bastions:
     effectRadius: 50
     includeY: true
     startScaleFactor: 10
-    finalScaleFactor: 0.95
+    finalScaleFactor: 1.00
     warmupTime: 172800000
     erosionPerDay: 0
     regenPerDay: 5

--- a/Bastion/config.yml
+++ b/Bastion/config.yml
@@ -27,7 +27,7 @@ bastions:
     effectRadius: 10
     includeY: true
     startScaleFactor: 10
-    finalScaleFactor: 0.75
+    finalScaleFactor: 0.95
     warmupTime: 172800000
     erosionPerDay: 0
     regenPerDay: 5
@@ -63,7 +63,7 @@ bastions:
     effectRadius: 50
     includeY: true
     startScaleFactor: 10
-    finalScaleFactor: 0.75
+    finalScaleFactor: 0.95
     warmupTime: 172800000
     erosionPerDay: 0
     regenPerDay: 5


### PR DESCRIPTION
reduces the time it takes to break a regular Bastion or City Bastion; cutting down on tedium, needs a more significant reduction tbh but this at least gets the ball rolling.