### PR TITLE
Nerfs Bastion warm up time

### DIFF
--- a/Bastion/config.yml
+++ b/Bastion/config.yml
@@ -28,7 +28,7 @@ bastions:
     includeY: true
     startScaleFactor: 10
     finalScaleFactor: 1.00
-    warmupTime: 172800000
+    warmupTime: 345600000
     erosionPerDay: 0
     regenPerDay: 5
     blocksToErode: -1


### PR DESCRIPTION
Doubles the amount of time it takes for Sponge Bastions to warm up, allowing actual sieges to take place. This change would take it from 2 days to 4 days, giving a good time window for defense / offense to take place.